### PR TITLE
Segments fail to render in MIP viewport unless drawn at center of normal viewport

### DIFF
--- a/packages/tools/examples/labelmapSegmentationTools/index.ts
+++ b/packages/tools/examples/labelmapSegmentationTools/index.ts
@@ -418,11 +418,30 @@ async function run() {
   // Set the volume to load
   // volume.load();
 
+  const dimensions = volume.dimensions;
+  const slabThickness = Math.sqrt(
+    dimensions[0] * dimensions[0] +
+      dimensions[1] * dimensions[1] +
+      dimensions[2] * dimensions[2]
+  );
+
   // Set volumes on the viewports
   await setVolumesForViewports(
     renderingEngine,
     [{ volumeId, callback: setCtTransferFunctionForVolumeActor }],
-    [viewportId1, viewportId2, viewportId3]
+    [viewportId1, viewportId3]
+  );
+
+  await setVolumesForViewports(
+    renderingEngine,
+    [
+      {
+        volumeId,
+        blendMode: Enums.BlendModes.MAXIMUM_INTENSITY_BLEND,
+        slabThickness,
+      },
+    ],
+    [viewportId2]
   );
 
   // Add the segmentation representation to the viewports
@@ -439,6 +458,27 @@ async function run() {
 
   // Render the image
   renderingEngine.render();
+
+  const button = document.createElement('button');
+  button.innerText = 'Debug';
+  button.addEventListener('click', () => {
+    const viewport2 = renderingEngine.getViewport(viewportId2);
+
+    const map = viewport2._actors;
+    for (const actorEntry of viewport2.getActors()) {
+      const { actor } = actorEntry;
+      const mapper = actor.getMapper();
+
+      console.log('--------');
+      console.log('RefId: ', actorEntry.referencedId);
+      console.log('BlendMode: ', mapper.getBlendModeAsString());
+      console.log('SlabThickness: ', actorEntry.slabThickness);
+
+      actorEntry.slabThickness = slabThickness;
+    }
+    renderingEngine.render();
+  });
+  content.appendChild(button);
 }
 
 run();


### PR DESCRIPTION
When setting the viewport to MIP (Maximum Intensity Projection), I encountered an issue where the volume is displayed in the MIP mode, but the segment is not.

To reproduce and debug this behavior, I slightly modified the example code for `labelmapSegmentationTools`. After running the following command, you can verify the behavior at http://localhost:3000:

```sh
yarn run example labelmapSegmentationTools
```

In this reproduction example, one viewport is set to display normally in the axial plane, while another is set to MIP in the sagittal plane. When drawing a segment in the normally displayed viewport, I expected the segment to appear in the MIP viewport regardless of where it was drawn. However, in reality, the segment only appears in the MIP viewport when it is drawn in the center of the normally displayed viewport.

For debugging purposes, a 'Debug' button has been added to this example to log the actor information for the MIP viewport via `console.log`. Upon investigation, I noticed that only the segment’s actor had an `undefined` `slabThickness`, which I suspected was the cause. To test this, I modified the ‘Debug’ button’s processing to assign the same `slabThickness` value to the segment’s actor as the volume.

However, even after updating the `slabThickness`, the segment still did not appear in the MIP viewport.


https://github.com/user-attachments/assets/0ae08d4a-1392-4c73-bc52-c35c1ea81230

